### PR TITLE
Add round trip tests for field circe codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,28 @@ Purely functional Scala DSLs for Contentful APIs
 Contentful has a lot of features which we haven't needed but may be added in future. These are the ones we know about.
 
 ### Field validations
-There are highly specific field validations being added all the time. These are some we're yet to support. Content Management API details are included where known.
+There are highly specific field validations and customisation being added to Contentful regularly. These are some we're yet to support. Content Management API details are included where known.
 
-- Symbol / Text / Symbol list :
+- Symbol / Text / Symbol list:
    - Prohibiting regex strings: `prohibitRegexp`
    - Regex flags, e.g. `"flags": "i"`
+   - Custom error message for accepting only specified values
+- Integer / Decimal:
+   - Custom error message for accepting only specified values
+- Decimal:
+   - Accept a range min/max and custom error message
+- Json:
+   - Custom error message for property range
 - Asset / Asset list:
    - Image dimensions in pixels: `assetImageDimensions`
    - File size in B/KB/MB: `assetFileSize`
+   - Custom error message for allowed mime type groups
+- Entry / Entry list
+   - Custom error message for allowed content types
+- DateTime
+   - Custom error message for date range
+- RichText
+   - Accept a character range min/max and custom error message
+
+### Quirks
+- `contentless` normalises date fields to use `ZonedDateTime` where possible. This works around how Contentful allows many different types to be stored in the same field; returned in the API as a string.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # contentless
 Purely functional Scala DSLs for Contentful APIs
+
+
+## Unsupported 
+Contentful has a lot of features which we haven't needed but may be added in future. These are the ones we know about.
+
+### Field validations
+There are highly specific field validations being added all the time. These are some we're yet to support. Content Management API details are included where known.
+
+- Symbol / Text / Symbol list :
+   - Prohibiting regex strings: `prohibitRegexp`
+   - Regex flags, e.g. `"flags": "i"`
+- Asset / Asset list:
+   - Image dimensions in pixels: `assetImageDimensions`
+   - File size in B/KB/MB: `assetFileSize`

--- a/core/src/main/scala/io/dantb/contentless/ContentModel.scala
+++ b/core/src/main/scala/io/dantb/contentless/ContentModel.scala
@@ -107,7 +107,8 @@ object Validation:
     case xs :+ last => s"Only ${xs.mkString(", ")} and $last $tpe are allowed".some
     case _          => None
 
-  final case class Size(min: Option[Int], max: Option[Int], message: Option[String]) extends Validation
+  final case class Size(min: Option[Int], max: Option[Int], message: Option[String], tpe: "size" | "range")
+      extends Validation
   final case class DateRange(min: Option[ZonedDateTime], max: Option[ZonedDateTime]) extends Validation
   case object Unique                                                                 extends Validation
 

--- a/core/src/main/scala/io/dantb/contentless/ContentModel.scala
+++ b/core/src/main/scala/io/dantb/contentless/ContentModel.scala
@@ -111,7 +111,9 @@ object Validation:
   final case class DateRange(min: Option[ZonedDateTime], max: Option[ZonedDateTime]) extends Validation
   case object Unique                                                                 extends Validation
 
-  enum Regexp(val underlying: Regex) extends Validation:
+  final case class RegexpValidation(regexp: Regexp, message: Option[String]) extends Validation
+
+  enum Regexp(val underlying: Regex):
     case Url
         extends Regexp("^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$".r)
     case Email                  extends Regexp("^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$".r)

--- a/core/src/main/scala/io/dantb/contentless/FieldType.scala
+++ b/core/src/main/scala/io/dantb/contentless/FieldType.scala
@@ -6,7 +6,7 @@ import cats.Eq
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import io.dantb.contentless.RichText.Mark
-import io.dantb.contentless.Validation.{Regexp, RichTextNodes}
+import io.dantb.contentless.Validation.{Regexp, RegexpValidation, RichTextNodes}
 
 import scala.util.matching.Regex
 
@@ -20,7 +20,7 @@ object FieldType:
       longText: Boolean,
       charBounds: Option[Validation.Size],
       allowedValues: Option[NonEmptyList[String]],
-      matchesRegex: Option[Regexp]
+      matchesRegex: Option[RegexpValidation]
   ) extends FieldType:
     def validations: Set[Validation] =
       charBounds.toSet ++ matchesRegex.toSet ++ allowedValues.map(Validation.ContainedIn(_)).toSet
@@ -28,7 +28,7 @@ object FieldType:
     def fromValidations(longText: Boolean, vs: Set[Validation]): Text =
       val size          = vs.collectFirst { case s: Validation.Size => s }
       val allowedValues = vs.collectFirst { case s: Validation.ContainedIn => s }.map(_.allowedValues)
-      val matchesRegex  = vs.collectFirst { case s: Validation.Regexp => s }
+      val matchesRegex  = vs.collectFirst { case s: Validation.RegexpValidation => s }
       Text(longText, size, allowedValues, matchesRegex)
 
   final case class Media(mimeTypeGroup: Set[MimeTypeGroup]) extends FieldType

--- a/core/src/main/scala/io/dantb/contentless/RichText.scala
+++ b/core/src/main/scala/io/dantb/contentless/RichText.scala
@@ -38,10 +38,12 @@ object RichText:
   case class Document(content: List[Node]) extends Node
 
   enum Mark(val asString: String):
-    case Bold      extends Mark("bold")
-    case Italic    extends Mark("italic")
-    case Underline extends Mark("underline")
-    case Code      extends Mark("code")
+    case Bold        extends Mark("bold")
+    case Italic      extends Mark("italic")
+    case Underline   extends Mark("underline")
+    case Code        extends Mark("code")
+    case Subscript   extends Mark("subscript")
+    case Superscript extends Mark("superscript")
   object Mark:
     def from(str: String): Option[Mark] = Mark.values.find(_.asString == str)
 

--- a/core/src/main/scala/io/dantb/contentless/codecs/EntryCodec.scala
+++ b/core/src/main/scala/io/dantb/contentless/codecs/EntryCodec.scala
@@ -9,7 +9,7 @@ import io.circe.{Decoder, Encoder, Json}
 import io.circe.syntax.*
 import io.dantb.contentless.*
 import io.dantb.contentless.RichText.{Mark, Node}
-import io.dantb.contentless.Validation.{Regexp, RichTextNodes}
+import io.dantb.contentless.Validation.{RegexpValidation, RichTextNodes}
 import io.dantb.contentless.appearance.*
 import io.dantb.contentless.appearance.Control.*
 import io.dantb.contentless.appearance.Editor.BuiltIn.EntryEditor
@@ -202,7 +202,7 @@ object FieldCodec:
         defaultValue: Option[String] = None,
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
-        matchesRegex: Option[Regexp] = None,
+        matchesRegex: Option[RegexpValidation] = None,
         textControl: LongTextControl = Control.BuiltIn.Markdown.longText
     ): FieldCodec[String] =
       new FieldCodec[String](
@@ -220,7 +220,7 @@ object FieldCodec:
         defaultValue: Option[String] = None,
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
-        matchesRegex: Option[Regexp] = None,
+        matchesRegex: Option[RegexpValidation] = None,
         textControl: TextControl = Control.BuiltIn.SingleLine.text
     ): FieldCodec[String] =
       new FieldCodec[String](
@@ -380,7 +380,7 @@ object FieldCodec:
         arrayBounds: Option[Validation.Size] = None,
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
-        matchesRegex: Option[Regexp] = None,
+        matchesRegex: Option[RegexpValidation] = None,
         textListControl: TextListControl = Control.BuiltIn.TagEditor.textList
     ): FieldCodec[List[String]] =
       new FieldCodec[List[String]](

--- a/core/src/main/scala/io/dantb/contentless/codecs/EntryCodec.scala
+++ b/core/src/main/scala/io/dantb/contentless/codecs/EntryCodec.scala
@@ -88,7 +88,7 @@ object EntryCodec extends TwiddleSyntax[EntryCodec]:
     override def write(value: Unit): Map[String, Json]                = Map.empty
     override val schema: List[Field]                                  = Nil
 
-  implicit def invariantMonoidal: InvariantMonoidal[EntryCodec] =
+  given invariantMonoidal: InvariantMonoidal[EntryCodec] =
     new InvariantMonoidal[EntryCodec]:
       override def unit: EntryCodec[Unit] = EntryCodec.unit
       override def product[A, B](fa: EntryCodec[A], fb: EntryCodec[B]): EntryCodec[(A, B)] =
@@ -203,11 +203,12 @@ object FieldCodec:
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
         matchesRegex: Option[RegexpValidation] = None,
+        unique: Boolean = false,
         textControl: LongTextControl = Control.BuiltIn.Markdown.longText
     ): FieldCodec[String] =
       new FieldCodec[String](
         fieldId,
-        FieldType.Text(longText = true, charBounds, allowedValues, matchesRegex),
+        FieldType.Text(longText = true, charBounds, allowedValues, matchesRegex, unique),
         fieldName,
         defaultValue,
         textControl.value,
@@ -221,11 +222,12 @@ object FieldCodec:
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
         matchesRegex: Option[RegexpValidation] = None,
+        unique: Boolean = false,
         textControl: TextControl = Control.BuiltIn.SingleLine.text
     ): FieldCodec[String] =
       new FieldCodec[String](
         fieldId,
-        FieldType.Text(longText = false, charBounds, allowedValues, matchesRegex),
+        FieldType.Text(longText = false, charBounds, allowedValues, matchesRegex, unique),
         fieldName,
         defaultValue,
         textControl.value,
@@ -252,11 +254,13 @@ object FieldCodec:
         fieldName: String,
         defaultValue: Option[Int] = None,
         allowedValues: Option[NonEmptyList[Int]] = None,
+        range: Option[Validation.Size] = None,
+        unique: Boolean = false,
         intControl: IntControl = Control.BuiltIn.NumberEditor.integer
     ): FieldCodec[Int] =
       new FieldCodec[Int](
         fieldId,
-        FieldType.Integer(allowedValues),
+        FieldType.Integer(allowedValues, range, unique),
         fieldName,
         defaultValue,
         intControl.value,
@@ -268,11 +272,12 @@ object FieldCodec:
         fieldName: String,
         defaultValue: Option[Double] = None,
         allowedValues: Option[NonEmptyList[Double]] = None,
+        unique: Boolean = false,
         numControl: NumControl = Control.BuiltIn.NumberEditor.number
     ): FieldCodec[Double] =
       new FieldCodec[Double](
         fieldId,
-        FieldType.Number(allowedValues),
+        FieldType.Number(allowedValues, unique),
         fieldName,
         defaultValue,
         numControl.value,
@@ -381,11 +386,12 @@ object FieldCodec:
         charBounds: Option[Validation.Size] = None,
         allowedValues: Option[NonEmptyList[String]] = None,
         matchesRegex: Option[RegexpValidation] = None,
+        unique: Boolean = false,
         textListControl: TextListControl = Control.BuiltIn.TagEditor.textList
     ): FieldCodec[List[String]] =
       new FieldCodec[List[String]](
         fieldId,
-        FieldType.Array(FieldType.Text(longText = false, charBounds, allowedValues, matchesRegex), arrayBounds),
+        FieldType.Array(FieldType.Text(longText = false, charBounds, allowedValues, matchesRegex, unique), arrayBounds),
         fieldName,
         defaultValue,
         textListControl.value,

--- a/core/src/main/scala/io/dantb/contentless/dsl/dsl.scala
+++ b/core/src/main/scala/io/dantb/contentless/dsl/dsl.scala
@@ -6,10 +6,23 @@ import io.dantb.contentless.codecs.FieldCodec.Dsl
 trait dsl extends Dsl
 
 object dsl extends dsl:
-  final case class ContentType[A](
-      contentType: ContentTypeId,
-      contentTypeName: String,
-      displayField: Option[String],
-      description: Option[String],
-      codec: EntryCodec[A]
-  )
+
+  trait ContentType[A]:
+    def contentType: ContentTypeId
+    def contentTypeName: String
+    def displayField: Option[String]
+    def description: Option[String]
+    def codec: EntryCodec[A]
+
+  def contentType[A](
+      contentType0: ContentTypeId,
+      contentTypeName0: String,
+      displayField0: Option[String],
+      description0: Option[String],
+      codec0: EntryCodec[A]
+  ): ContentType[A] = new ContentType[A]:
+    def contentType: ContentTypeId   = contentType0
+    def contentTypeName: String      = contentTypeName0
+    def displayField: Option[String] = displayField0
+    def description: Option[String]  = description0
+    def codec: EntryCodec[A]         = codec0

--- a/core/src/test/scala/io/dantb/contentless/arbitrary.scala
+++ b/core/src/test/scala/io/dantb/contentless/arbitrary.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Arbitrary.{arbitrary as arb}
 object arbitrary:
 
   // library types
-  given [A: Arbitrary]: Arbitrary[NonEmptyList[A]] = Arbitrary(genNel(summon[Arbitrary[A]].arbitrary))
+  given [A: Arbitrary]: Arbitrary[NonEmptyList[A]] = Arbitrary(genNel(arb[A]))
 
   // newtypes
   given Arbitrary[ContentTypeId] = Arbitrary(genUuidString.map(ContentTypeId(_)))
@@ -50,11 +50,16 @@ object arbitrary:
     linkContentType <- opt[LinkContentType]
   yield RichTextNodes.EntryInline(size, linkContentType)
 
-  def genSize: Gen[Validation.Size] = for
-    min     <- opt[Int]
-    max     <- opt[Int]
-    message <- opt[String]
-  yield Validation.Size(min, max, message)
+  def genSize: Gen[Validation.Size] =
+    for
+      min     <- opt[Int]
+      max     <- opt[Int]
+      message <- opt[String]
+      tpe <- Gen.oneOf["size" | "range"](
+        "size",
+        "range"
+      ) // tried to generalise this but you get an "Implicit search problem too large"
+    yield Validation.Size(min, max, message, tpe)
 
   def genLinkContentType: Gen[LinkContentType] = for
     allowedContentTypes <- arb[Set[String]]

--- a/core/src/test/scala/io/dantb/contentless/codecs/CirceSpec.scala
+++ b/core/src/test/scala/io/dantb/contentless/codecs/CirceSpec.scala
@@ -1,0 +1,634 @@
+package io.dantb.contentless.codecs
+
+import cats.data.NonEmptyList
+import io.circe.{Decoder, Json, Printer}
+import io.circe.literal.*
+import io.circe.syntax.*
+import io.dantb.contentless.{ContentTypeId, Field, Validation}
+import io.dantb.contentless.Validation.Regexp
+import io.dantb.contentless.codecs.implicits.given
+import io.dantb.contentless.dsl.*
+import io.dantb.contentless.instances.given
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+
+class CirceSpec extends ScalaCheckSuite:
+
+  test("long text field serialisation round trip") {
+    val field = longText(
+      "longTextField",
+      "Long Text Field",
+      defaultValue = Some("donald.duck@gmail.com"),
+      charBounds = Some(Validation.Size(Some(0), Some(50), Some("Must be between 0 and 50 characters"))),
+      matchesRegex = Some(Validation.RegexpValidation(Regexp.Email, Some("Must match email regex case insensitively")))
+    ).required
+
+    val j = json"""
+  {
+    "id": "longTextField",
+    "name": "Long Text Field",
+    "type": "Text",
+    "localized": false,
+    "required": true,
+    "validations": [
+      {
+        "size": {
+          "min": 0,
+          "max": 50
+        },
+        "message": "Must be between 0 and 50 characters"
+      },
+      {
+        "regexp": {
+          "pattern": "^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$$"
+        },
+        "message": "Must match email regex case insensitively"
+      }
+    ],
+    "defaultValue": {
+      "en-GB": "donald.duck@gmail.com"
+    },
+    "disabled": false
+  }
+    """
+
+    val written: Json               = field.schema.head.asJson
+    val read: Decoder.Result[Field] = j.as[Field]
+
+    assertEquals(written.print, j.print)
+    assertEquals(read, Right(field.schema.head))
+  }
+
+  extension (j: Json) def print: String = j.printWith(Printer.spaces2SortKeys)
+
+  def fullResponse: Json = json"""
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "9wt1zvqpsy8o"
+            }
+        },
+        "id": "allFieldTypes",
+        "type": "ContentType",
+        "createdAt": "2023-05-18T12:22:18.599Z",
+        "updatedAt": "2023-05-18T13:20:01.560Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "publishedVersion": 33,
+        "publishedAt": "2023-05-18T13:20:01.560Z",
+        "firstPublishedAt": "2023-05-18T12:22:19.005Z",
+        "createdBy": {
+            "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "6gaSKdIG0FToScPLiTwecW"
+            }
+        },
+        "updatedBy": {
+            "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "6gaSKdIG0FToScPLiTwecW"
+            }
+        },
+        "publishedCounter": 17,
+        "version": 34,
+        "publishedBy": {
+            "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "6gaSKdIG0FToScPLiTwecW"
+            }
+        }
+    },
+    "displayField": "longTextField",
+    "name": "All Field Types",
+    "description": "This content type has every field type with validations enabled (minus all permutations). Used to generated an API response for round trip Scala DSL tests.",
+    "fields": [
+        {
+            "id": "longTextField",
+            "name": "Long Text Field",
+            "type": "Text",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 50
+                    },
+                    "message": "Must be between 0 and 50 characters"
+                },
+                {
+                    "regexp": {
+                        "pattern": "^\\w[\\w.-]*@([\\w-]+\\.)+[\\w-]+$",
+                        "flags": "i"
+                    },
+                    "message": "Must match email regex case insensitively"
+                },
+                {
+                    "prohibitRegexp": {
+                        "pattern": "mickey.mouse@hotmail.com",
+                        "flags": "i"
+                    },
+                    "message": "Mickey mouse isn't allowed"
+                }
+            ],
+            "defaultValue": {
+                "en-GB": "donald.duck@gmail.com"
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "shortTextField",
+            "name": "Short Text Field Unique URL",
+            "type": "Symbol",
+            "localized": false,
+            "required": false,
+            "validations": [
+                {
+                    "unique": true
+                },
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 20
+                    },
+                    "message": "Must be between 0 and 20 characters"
+                },
+                {
+                    "regexp": {
+                        "pattern": "^(ftp|http|https):\/\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\/|\/([\\w#!:.?+=&%@!\\-/]))?$",
+                        "flags": null
+                    },
+                    "message": "Must be a valid URL"
+                },
+                {
+                    "in": [
+                        "https://www.itv.com",
+                        "https://itv.com/news",
+                        "https://papertoilet.com/"
+                    ],
+                    "message": "Must match predefined URLs"
+                }
+            ],
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "shortTextFieldDefaulted",
+            "name": "Short Text Field Defaulted",
+            "type": "Symbol",
+            "localized": false,
+            "required": true,
+            "validations": [],
+            "defaultValue": {
+                "en-GB": "Eggy"
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "booleanField",
+            "name": "Boolean Field",
+            "type": "Boolean",
+            "localized": false,
+            "required": true,
+            "validations": [],
+            "defaultValue": {
+                "en-GB": true
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "integerField",
+            "name": "Integer Field",
+            "type": "Integer",
+            "localized": false,
+            "required": false,
+            "validations": [
+                {
+                    "range": {
+                        "min": -20,
+                        "max": 100
+                    },
+                    "message": "Range: [-20, 100]"
+                },
+                {
+                    "in": [
+                        -20,
+                        -10,
+                        0,
+                        50
+                    ],
+                    "message": "Should be -20, -10, 0 or 50"
+                }
+            ],
+            "defaultValue": {
+                "en-GB": -10
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "decimalField",
+            "name": "Decimal Field",
+            "type": "Number",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "range": {
+                        "min": 0,
+                        "max": 5
+                    },
+                    "message": "Range: [0, 5]"
+                },
+                {
+                    "in": [
+                        1.1,
+                        2.2,
+                        3.3,
+                        4.4
+                    ],
+                    "message": "Invalid decimal value"
+                }
+            ],
+            "defaultValue": {
+                "en-GB": 2.2
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "jsonField",
+            "name": "Json Field",
+            "type": "Object",
+            "localized": false,
+            "required": false,
+            "validations": [
+                {
+                    "size": {
+                        "min": 1,
+                        "max": 10
+                    },
+                    "message": "JSON must have between 1 and 10 properties"
+                }
+            ],
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "localDateTimeField",
+            "name": "Local Date Time Field",
+            "type": "Date",
+            "localized": false,
+            "required": false,
+            "validations": [
+                {
+                    "dateRange": {
+                        "after": null,
+                        "before": null,
+                        "max": "2023-05-26"
+                    },
+                    "message": "Not in date range"
+                }
+            ],
+            "defaultValue": {
+                "en-GB": "2023-05-20T00:00+01:00"
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "zonedDateTimeField",
+            "name": "Zoned Date Time Field",
+            "type": "Date",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "dateRange": {
+                        "after": null,
+                        "before": null,
+                        "max": "2023-06-21"
+                    },
+                    "message": "Must be in range"
+                }
+            ],
+            "defaultValue": {
+                "en-GB": "2023-05-30T00:00+01:00"
+            },
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "locationField",
+            "name": "Location Field",
+            "type": "Location",
+            "localized": false,
+            "required": true,
+            "validations": [],
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "richTextField",
+            "name": "Rich Text Field",
+            "type": "RichText",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 1000
+                    },
+                    "message": "Must be between 0 and 1000 characters"
+                },
+                {
+                    "enabledMarks": [
+                        "bold",
+                        "italic",
+                        "underline",
+                        "code",
+                        "superscript",
+                        "subscript"
+                    ],
+                    "message": "Only bold, italic, underline, code, superscript, and subscript marks are allowed"
+                },
+                {
+                    "enabledNodeTypes": [
+                        "heading-1",
+                        "heading-2",
+                        "heading-3",
+                        "heading-4",
+                        "heading-5",
+                        "heading-6",
+                        "ordered-list",
+                        "unordered-list",
+                        "hr",
+                        "blockquote",
+                        "embedded-entry-block",
+                        "embedded-asset-block",
+                        "table",
+                        "hyperlink",
+                        "entry-hyperlink",
+                        "asset-hyperlink",
+                        "embedded-entry-inline"
+                    ],
+                    "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed"
+                },
+                {
+                    "nodes": {
+                        "asset-hyperlink": [
+                            {
+                                "size": {
+                                    "min": 4,
+                                    "max": 5
+                                },
+                                "message": "Must be between 4 and 5 asset links"
+                            }
+                        ],
+                        "embedded-asset-block": [
+                            {
+                                "size": {
+                                    "min": 3,
+                                    "max": 4
+                                },
+                                "message": "Must be between 3 and 4 assets"
+                            }
+                        ],
+                        "embedded-entry-block": [
+                            {
+                                "linkContentType": [
+                                    "allFieldTypes",
+                                    "embed"
+                                ],
+                                "message": "Invalid block entry type"
+                            },
+                            {
+                                "size": {
+                                    "min": 2,
+                                    "max": 3
+                                },
+                                "message": "Must be between 2 and 3 entries"
+                            }
+                        ],
+                        "embedded-entry-inline": [
+                            {
+                                "linkContentType": [
+                                    "allFieldTypes",
+                                    "collection"
+                                ],
+                                "message": "Invalid inline entry type"
+                            },
+                            {
+                                "size": {
+                                    "min": 5,
+                                    "max": 6
+                                },
+                                "message": "Must be between 5 and 6 inline entries"
+                            }
+                        ],
+                        "entry-hyperlink": [
+                            {
+                                "linkContentType": [
+                                    "allFieldTypes",
+                                    "article"
+                                ],
+                                "message": "Invalid linked entry type"
+                            },
+                            {
+                                "size": {
+                                    "min": 1,
+                                    "max": 5
+                                },
+                                "message": "Must be between 1 and 5 entry links"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "disabled": false,
+            "omitted": false
+        },
+        {
+            "id": "textListField",
+            "name": "Text List Field",
+            "type": "Array",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 5
+                    },
+                    "message": "Must have 0-5 symbols"
+                }
+            ],
+            "disabled": false,
+            "omitted": false,
+            "items": {
+                "type": "Symbol",
+                "validations": [
+                    {
+                        "size": {
+                            "min": 0,
+                            "max": 10
+                        },
+                        "message": "Must be between 0 and 10 characters"
+                    },
+                    {
+                        "regexp": {
+                            "pattern": "[a-zA-Z]",
+                            "flags": "g"
+                        },
+                        "message": "Should be some letters"
+                    },
+                    {
+                        "in": [
+                            "banana",
+                            "bread",
+                            "egg",
+                            "beans"
+                        ],
+                        "message": "Must be banana bread egg beans"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "assetField",
+            "name": "Asset Field",
+            "type": "Link",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "linkMimetypeGroup": [
+                        "attachment",
+                        "plaintext"
+                    ],
+                    "message": "Only attachment or plaintext allowed"
+                },
+                {
+                    "assetImageDimensions": {
+                        "width": {
+                            "min": 6,
+                            "max": null
+                        },
+                        "height": {
+                            "min": 501,
+                            "max": null
+                        }
+                    },
+                    "message": "Must be at least 600x500"
+                },
+                {
+                    "assetFileSize": {
+                        "min": 0,
+                        "max": 104857600
+                    },
+                    "message": "Must be 0-100MB"
+                }
+            ],
+            "disabled": false,
+            "omitted": false,
+            "linkType": "Asset"
+        },
+        {
+            "id": "multipleAssetsField",
+            "name": "Multiple Assets Field",
+            "type": "Array",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 6
+                    },
+                    "message": "0-6 assets pls"
+                }
+            ],
+            "disabled": false,
+            "omitted": false,
+            "items": {
+                "type": "Link",
+                "validations": [
+                    {
+                        "linkMimetypeGroup": [
+                            "image",
+                            "audio"
+                        ],
+                        "message": "image or audio pls"
+                    }
+                ],
+                "linkType": "Asset"
+            }
+        },
+        {
+            "id": "entryReferenceField",
+            "name": "Entry Reference Field",
+            "type": "Link",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "linkContentType": [
+                        "image",
+                        "quotation"
+                    ],
+                    "message": "Invalid content type for entry"
+                }
+            ],
+            "disabled": false,
+            "omitted": false,
+            "linkType": "Entry"
+        },
+        {
+            "id": "multipleEntryReferencesField",
+            "name": "Multiple Entry References Field",
+            "type": "Array",
+            "localized": false,
+            "required": true,
+            "validations": [
+                {
+                    "size": {
+                        "min": 0,
+                        "max": 11
+                    },
+                    "message": "0-11 pls"
+                }
+            ],
+            "disabled": false,
+            "omitted": false,
+            "items": {
+                "type": "Link",
+                "validations": [
+                    {
+                        "linkContentType": [
+                            "collection",
+                            "accordion"
+                        ],
+                        "message": "Invalid entry type"
+                    }
+                ],
+                "linkType": "Entry"
+            }
+        }
+    ]
+}
+  """

--- a/core/src/test/scala/io/dantb/contentless/codecs/EntryCodecSpec.scala
+++ b/core/src/test/scala/io/dantb/contentless/codecs/EntryCodecSpec.scala
@@ -1,19 +1,3 @@
-// /*
-//  * Copyright 2023 Typelevel
-//  *
-//  * Licensed under the Apache License, Version 2.0 (the "License");
-//  * you may not use this file except in compliance with the License.
-//  * You may obtain a copy of the License at
-//  *
-//  *     http://www.apache.org/licenses/LICENSE-2.0
-//  *
-//  * Unless required by applicable law or agreed to in writing, software
-//  * distributed under the License is distributed on an "AS IS" BASIS,
-//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  * See the License for the specific language governing permissions and
-//  * limitations under the License.
-//  */
-
 package io.dantb.contentless.codecs
 
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}

--- a/core/src/test/scala/io/dantb/contentless/codecs/EntryCodecSpec.scala
+++ b/core/src/test/scala/io/dantb/contentless/codecs/EntryCodecSpec.scala
@@ -29,18 +29,18 @@ class EntryCodecSpec extends ScalaCheckSuite:
   }
 
   property("text field") {
-    forAll { (id: String, name: String, disabled: Boolean, default: Option[String]) =>
-      val fieldCodec        = text(id, name, defaultValue = default)
-      val expectedFieldType = FieldType.Text(longText = false, None, None, None)
+    forAll { (id: String, name: String, disabled: Boolean, default: Option[String], unique: Boolean) =>
+      val fieldCodec        = text(id, name, defaultValue = default, unique = unique)
+      val expectedFieldType = FieldType.Text(longText = false, None, None, None, unique)
 
       assertField(fieldCodec, id, name, disabled, expectedFieldType, default.map(_.asJson))
     }
   }
 
   property("long text field") {
-    forAll { (id: String, name: String, disabled: Boolean, default: Option[String]) =>
-      val fieldCodec        = longText(id, name, defaultValue = default)
-      val expectedFieldType = FieldType.Text(longText = true, None, None, None)
+    forAll { (id: String, name: String, disabled: Boolean, default: Option[String], unique: Boolean) =>
+      val fieldCodec        = longText(id, name, defaultValue = default, unique = unique)
+      val expectedFieldType = FieldType.Text(longText = true, None, None, None, unique)
 
       assertField(fieldCodec, id, name, disabled, expectedFieldType, default.map(_.asJson))
     }
@@ -48,9 +48,16 @@ class EntryCodecSpec extends ScalaCheckSuite:
 
   property("int field") {
     forAll {
-      (id: String, name: String, disabled: Boolean, default: Option[Int], allowedValues: Option[NonEmptyList[Int]]) =>
-        val fieldCodec        = int(id, name, default, allowedValues)
-        val expectedFieldType = FieldType.Integer(allowedValues)
+      (
+          id: String,
+          name: String,
+          disabled: Boolean,
+          default: Option[Int],
+          allowedValues: Option[NonEmptyList[Int]],
+          unique: Boolean
+      ) =>
+        val fieldCodec        = int(id, name, default, allowedValues, unique = unique)
+        val expectedFieldType = FieldType.Integer(allowedValues, None, unique)
 
         assertField(fieldCodec, id, name, disabled, expectedFieldType, default.map(_.asJson))
     }
@@ -58,9 +65,16 @@ class EntryCodecSpec extends ScalaCheckSuite:
 
   property("decimal field") {
     forAll {
-      (id: String, name: String, disabled: Boolean, default: Option[Double], allowedValues: Option[NonEmptyList[Double]]) =>
-        val fieldCodec        = decimal(id, name, default, allowedValues)
-        val expectedFieldType = FieldType.Number(allowedValues)
+      (
+          id: String,
+          name: String,
+          disabled: Boolean,
+          default: Option[Double],
+          allowedValues: Option[NonEmptyList[Double]],
+          unique: Boolean
+      ) =>
+        val fieldCodec        = decimal(id, name, default, allowedValues, unique = unique)
+        val expectedFieldType = FieldType.Number(allowedValues, unique)
 
         assertField(fieldCodec, id, name, disabled, expectedFieldType, default.map(_.asJson))
     }
@@ -166,9 +180,9 @@ class EntryCodecSpec extends ScalaCheckSuite:
   }
 
   property("text list field") {
-    forAll { (id: String, name: String, disabled: Boolean, default: Option[List[String]]) =>
-      val fieldCodec        = textList(id, name, defaultValue = default)
-      val expectedFieldType = FieldType.Array(FieldType.Text(longText = false, None, None, None), None)
+    forAll { (id: String, name: String, disabled: Boolean, default: Option[List[String]], unique: Boolean) =>
+      val fieldCodec        = textList(id, name, defaultValue = default, unique = unique)
+      val expectedFieldType = FieldType.Array(FieldType.Text(longText = false, None, None, None, unique), None)
 
       assertField(fieldCodec, id, name, disabled, expectedFieldType, default.map(_.asJson))
     }


### PR DESCRIPTION
Bit of a slog but this usefully revealed quite a few gaps in what we support, as well as changes Contentful have made to their API since this library was written. I've added these to the README.

As @umazalakain pointed out in https://github.com/dantb/contentless/pull/1, `Validation` needs a proper rewrite which I'll do separately; there are a few nasty decoding hacks here which won't be long-lived. For this change I just wanted to make sure we can JSON round trip with what's supported in the DSL (and added support a few low hanging things like new text marks, `unique` field support). Tests are in `CirceSpec` - having these will help refactoring with confidence.